### PR TITLE
Update pt_PT.lang and pt_BR.lang

### DIFF
--- a/res/romfs/lang/pt_BR.lang
+++ b/res/romfs/lang/pt_BR.lang
@@ -19,7 +19,7 @@ Failed to install update: 0x%08lX
 Falha ao instalar a atualização: 0x%08lX
 
 Checking latest cache...
-Verificando cache mais recente...
+Verificando o cache mais recente...
 
 Downloading latest cache: %s...
 Baixando o cache mais recente: %s...
@@ -68,7 +68,7 @@ Tem certeza que quer continuar?
 # src/AppInfo.cpp
 #################
 No Screenshots
-Sem Screenshots
+Sem Capturas de Tela
 
 No game selected
 Nenhum jogo selecionado
@@ -86,7 +86,7 @@ Queued demo: %s
 Demo em fila: %s
 
 You are deleting this game,\nincluding all save data:\n\n%s
-Você está excluindo este jogo,\nincluindo todos os dados salvos:\n\n%s
+Você está excluindo este jogo,\nincluindo todos os dados de gravação:\n\n%s
 
 Deleted: %s
 Excluiu: %s
@@ -129,7 +129,7 @@ Installing ticket...
 Instalando bilhete...
 
 Installing seed...
-Instalando semente...
+Instalando semente...
 
 Installing TMD...
 Instalando TMD...
@@ -147,7 +147,7 @@ Installed
 Instalado
 
 Completed: %s
-Completado: %s
+Completado: %s
 
 Failed: %s
 Falhou: %s
@@ -243,7 +243,7 @@ Request timed out.\nTry again.
 A solicitação expirou.\nTente novamente.
 
 Invalid URL.
-URL inválida.
+URL inválido.
 
 # src/GUI/Settings.cpp
 ######################
@@ -317,13 +317,13 @@ Russian
 Russo
 
 Filter settings saved
-Configurações de filtro salvas
+Configurações do filtro salvas
 
 Cleared saved filter settings
-Configurações de filtro apagadas
+Configurações do filtro apagadas
 
 Select All
-Tudo
+Todos
 
 Select None
 Nenhum
@@ -389,7 +389,7 @@ View news (%s)
 Ver notícias (%s)
 
 Enable screen sleep after inactivity
-Ativar tela de descanso após de inatividade
+Ativar tela de descanso após inatividade
 
 Remote title key URL(s)
 URL(s) remotos de chaves de títulos

--- a/res/romfs/lang/pt_PT.lang
+++ b/res/romfs/lang/pt_PT.lang
@@ -4,7 +4,7 @@ Waiting for internet connection... %.0fs
 Aguardando conexão de internet... %.0fs
 
 Fetching news for %s ...
-Buscando notícias para %s ...
+Procurando notícias para %s ...
 
 Loading game list...
 Carregando lista de jogos...
@@ -19,16 +19,16 @@ Failed to install update: 0x%08lX
 Falha ao instalar a atualização: 0x%08lX
 
 Checking latest cache...
-Verificando cache mais recente...
+Verificando a cache mais recente...
 
 Downloading latest cache: %s...
-Baixando o cache mais recente: %s...
+Transferindo a cache mais recente: %s...
 
 Extracting latest cache...
-Extraindo o cache mais recente...
+Extraindo a cache mais recente...
 
 Downloading title keys...
-Baixando as chaves de títulos...
+Transferindo as chaves de títulos...
 
 # src/States/BrowseState.cpp
 ############################
@@ -36,7 +36,7 @@ No title keys found.\nMake sure you have keys in\n%s\n\nManually copy keys to th
 Chaves de títulos não encontradas.\nVerifique se você tem as chaves em\n%s\n\nCopie manualmente as chaves para\no diretório ou verifique as configurações\npara digitar um URL para\no download das chaves.
 
 No cache entries found\nfor your title keys.\n\nTry refreshing cache in settings.\nIf that doesn't work, then your\ntitles simply won't work with\nfreeShop currently.
-Nenhuma entrada de cache encontrada\npara as suas chaves de títulos.\n\nTente atualizar o cache nas configurações.\nSe isso não funcionar, então seus\ntítulos simplesmente não irão funcionar\ncom a freeShop atualmente.
+Nenhuma entrada de cache encontrada\npara as suas chaves de títulos.\n\nTente atualizar a cache nas configurações.\nSe isso não funcionar, então seus\ntítulos simplesmente não irão funcionar\ncom a freeShop atualmente.
 
 Queued install: %s
 Instalação em fila: %s
@@ -68,7 +68,7 @@ Tem certeza que quer continuar?
 # src/AppInfo.cpp
 #################
 No Screenshots
-Sem Screenshots
+Sem Capturas de Ecrã
 
 No game selected
 Nenhum jogo selecionado
@@ -86,7 +86,7 @@ Queued demo: %s
 Demo em fila: %s
 
 You are deleting this game,\nincluding all save data:\n\n%s
-Você está excluindo este jogo,\nincluindo todos os dados salvos:\n\n%s
+Você está excluindo este jogo,\nincluindo todos os dados de gravação:\n\n%s
 
 Deleted: %s
 Excluiu: %s
@@ -243,7 +243,7 @@ Request timed out.\nTry again.
 A solicitação expirou.\nTente novamente.
 
 Invalid URL.
-URL inválida.
+URL inválido.
 
 # src/GUI/Settings.cpp
 ######################
@@ -269,7 +269,7 @@ Update
 Atualizar
 
 Download
-Baixar
+Transferir
 
 Other
 Outros
@@ -317,13 +317,13 @@ Russian
 Russo
 
 Filter settings saved
-Configurações de filtro salvas
+Configurações do filtro salvas
 
 Cleared saved filter settings
-Configurações de filtro apagadas
+Configurações do filtro apagadas
 
 Select All
-Tudo
+Todos
 
 Select None
 Nenhum
@@ -383,13 +383,13 @@ Language:
 Idioma:
 
 Auto-detect
-Auto Detecção
+Auto Deteção
 
 View news (%s)
 Ver notícias (%s)
 
 Enable screen sleep after inactivity
-Ativar tela de descanso após de inatividade
+Ativar ecrã de descanso após inatividade
 
 Remote title key URL(s)
 URL(s) remotos de chaves de títulos


### PR DESCRIPTION
The reason why I left the pt_BR file with masculine cache was because all brazilian articles/dictionary entries that I saw were refering to cache as masculine. But all portuguese articles/dictionary entries that I saw were refering to cache(in IT terms) as feminine.

**Brazilian:**
http://www.hardware.com.br/termos/cache
http://www.tecmundo.com.br/navegador/201-o-que-e-cache-.htm
https://www.significados.com.br/cache/
http://dicionarioportugues.org/pt/cache (looks portuguese at first but if you go to their about page they use "sinônimo" while european portuguese uses "sinónimo")

**Portuguese:**
http://www.priberam.pt/dlpo/cache
https://pplware.sapo.pt/tag/cache/
http://kodiportugal.pt/tutorial-como-fazer-zero-cache-e-adicionar-o-ficheiro-advancedsettings-xml/
https://www.ua.pt/stic/browser_cache
http://manuaisonline.vodafone.pt/web/nokia-5800-xpressmusic/explorar/outras-funcoes/limpe-a-cache/

I think that is enough. It's simply a dialect difference.